### PR TITLE
fix: z up

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ When adding via unpkg, the package can be accessed at `google.maps.plugins.three
 
 Checkout the the reference [documentation](https://googlemaps.github.io/js-three/index.html).
 
-> Note: All methods and objects in this library follow a default up axis of (0, 1, 0), y up, matching that of three.js.
-
-<img src="https://storage.googleapis.com/geo-devrel-public-buckets/orientation.jpg" alt="orientation of axes" width="400"/>
-
 ## Example
 
 The following example provides a skeleton for adding objects to the map with this library.
@@ -53,8 +49,12 @@ const box = new Mesh(
 
 // set position at center of map
 box.position.copy(latLngToVector3(mapOptions.center));
+
 // set position vertically
-box.position.setY(25);
+box.position.setZ(25);
+
+// rotate to match z up default of overlay
+box.rotateX(Math.PI / 2);
 
 // add box mesh to the scene
 scene.add(box);

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -46,13 +46,16 @@ new Loader(LOADER_OPTIONS).load().then(() => {
   // Create a box mesh
   const box = new Mesh(
     new BoxBufferGeometry(10, 50, 10),
-    new MeshNormalMaterial(),
+    new MeshNormalMaterial()
   );
 
   // set position at center of map
   box.position.copy(latLngToVector3(mapOptions.center));
   // set position vertically
-  box.position.setY(25);
+  box.position.setZ(25);
+
+  // rotate to match z up default of overlay
+  box.rotateX(Math.PI / 2);
 
   // add box mesh to the scene
   scene.add(box);

--- a/src/three.test.ts
+++ b/src/three.test.ts
@@ -40,7 +40,7 @@ test("instantiates with defaults", () => {
   expect(overlay["camera"]).toBeInstanceOf(PerspectiveCamera);
 
   expect(overlay.scene).toBeInstanceOf(Scene);
-  expect(overlay.scene.rotation.x).toEqual(Math.PI / 2);
+  expect(overlay.scene.rotation.x).toEqual(0);
 
   // required hooks must be defined
   expect(overlay["overlay"].onAdd).toBeDefined();

--- a/src/three.ts
+++ b/src/three.ts
@@ -41,9 +41,6 @@ export interface ThreeJSOverlayViewOptions {
 
 /**
  * Add a [three.js](https://threejs.org) scene as a [Google Maps WebglOverlayView](http://goo.gle/webgloverlayview-ref).
- *
- * **Note**: The scene will be rotated to a default up axis of (0, 1, 0) matching that of three.js.
- * *
  */
 export class ThreeJSOverlayView implements google.maps.WebglOverlayView {
   /**
@@ -75,9 +72,6 @@ export class ThreeJSOverlayView implements google.maps.WebglOverlayView {
     this.rotation = rotation;
     this.scale = scale;
     this.scene = scene;
-
-    // rotate scene consistent with y up in THREE
-    this.scene.rotation.x = Math.PI / 2;
 
     this.overlay.onAdd = this.onAdd.bind(this);
     this.overlay.onRemove = this.onRemove.bind(this);

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -73,8 +73,8 @@ test.each([
 ])("latLngToVector3 is correct", (latLng, projected) => {
   const vector = latLngToVector3(latLng);
   expect(vector.x).toBeCloseTo(projected.x);
-  expect(vector.y).toBeCloseTo(0);
-  expect(vector.z).toBeCloseTo(-projected.y);
+  expect(vector.y).toBeCloseTo(projected.y);
+  expect(vector.z).toBeCloseTo(0);
 });
 
 test("latLngToVector3Relative is correct", () => {
@@ -84,6 +84,6 @@ test("latLngToVector3Relative is correct", () => {
   );
 
   expect(relative.x).toBeCloseTo(-111195.10117748393);
-  expect(relative.y).toBeCloseTo(0);
-  expect(relative.z).toBeCloseTo(-111200.74693490766);
+  expect(relative.y).toBeCloseTo(-111200.74693490766);
+  expect(relative.z).toBeCloseTo(0);
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -50,26 +50,26 @@ export function latLngToMeters(
 }
 
 /**
- * Converts latitude and longitude to world space coordinates with y up.
+ * Converts latitude and longitude to world space coordinates.
  */
 export function latLngToVector3(
   point: google.maps.LatLngLiteral | google.maps.LatLng,
   target = new Vector3()
-) {
+): Vector3 {
   const { x, y } = latLngToMeters(point);
 
-  return target.set(x, 0, -y);
+  return target.set(x, y, 0);
 }
 
 /**
  * Converts latitude and longitude to world space coordinates relative
- * to a reference location with y up.
+ * to a reference location.
  */
 export function latLngToVector3Relative(
   point: google.maps.LatLngLiteral | google.maps.LatLng,
   reference: google.maps.LatLngLiteral | google.maps.LatLng,
   target = new Vector3()
-) {
+): Vector3 {
   const p = latLngToVector3(point);
   const r = latLngToVector3(reference);
 


### PR DESCRIPTION
Use z-up instead of y-up. This requires rotating objects or possibly applying rotation to overlay.

closes #23 