### PR TITLE
Fix incorrect default import of three

### DIFF
--- a/src/three.ts
+++ b/src/three.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type three from "three";
+import type * as three from "three";
 
 export type MinimalThree = Pick<
   typeof three,


### PR DESCRIPTION
Build / lint currently fails with:
`Error: node_modules/@googlemaps/three/dist/three.d.ts:17:13 - error TS1192: Module '"/Users/teledemic/Documents/projects/ng_dvs/node_modules/@types/three/index"' has no default export.`
Importing three as * rather than a default export fixes this