### PR TITLE
fix: threejs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,15 @@ The following example provides a skeleton for adding objects to the map with thi
 
 ```js
 import * as THREE from 'three';
+
 const map = new google.maps.Map(document.getElementById("map"), mapOptions);
 // instantiate a ThreeJS Scene
 const scene = new THREE.Scene();
 
 // Create a box mesh
-const box = new Mesh(
-  new BoxBufferGeometry(10, 50, 10),
-  new MeshNormalMaterial(),
+const box = new THREE.Mesh(
+  new THREE.BoxGeometry(10, 50, 10),
+  new THREE.MeshNormalMaterial(),
 );
 
 // set position at center of map

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -39,7 +39,7 @@ new Loader(LOADER_OPTIONS).load().then(() => {
 
   // Create a box mesh
   const box = new THREE.Mesh(
-    new THREE.BoxBufferGeometry(10, 50, 10),
+    new THREE.BoxGeometry(10, 50, 10),
     new THREE.MeshNormalMaterial()
   );
 

--- a/examples/hemispheres.ts
+++ b/examples/hemispheres.ts
@@ -44,7 +44,7 @@ new Loader(LOADER_OPTIONS).load().then(() => {
   ].forEach((latLng: google.maps.LatLngLiteral) => {
     // Create a box mesh
     const box = new THREE.Mesh(
-      new THREE.BoxBufferGeometry(10, 50, 10),
+      new THREE.BoxGeometry(10, 50, 10),
       new THREE.MeshNormalMaterial()
     );
 

--- a/examples/treeshake.ts
+++ b/examples/treeshake.ts
@@ -21,7 +21,7 @@ import {
   PCFSoftShadowMap,
   sRGBEncoding,
   Mesh,
-  BoxBufferGeometry,
+  BoxGeometry,
   MeshNormalMaterial,
   MathUtils,
 } from "three";
@@ -49,10 +49,7 @@ new Loader(LOADER_OPTIONS).load().then(() => {
   const scene = new Scene();
 
   // Create a box mesh
-  const box = new Mesh(
-    new BoxBufferGeometry(10, 50, 10),
-    new MeshNormalMaterial()
-  );
+  const box = new Mesh(new BoxGeometry(10, 50, 10), new MeshNormalMaterial());
 
   // set position at center of map
   box.position.copy(latLngToVector3(mapOptions.center));


### PR DESCRIPTION
Last year, [three.js deprecated the `XxxBufferGeometry` classes](https://github.com/mrdoob/three.js/pull/24352), this change adjust example code to no longer use them and use the new versions instead.