### PR TITLE
feat: introduce onBeforeDraw callback

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,10 @@
         "@typescript-eslint/ban-types": 1,
         "@typescript-eslint/no-empty-function": 1,
         "@typescript-eslint/member-ordering": 1,
+        "@typescript-eslint/no-unused-vars": [
+          1,
+          { "vars": "all", "args": "none" }
+        ],
         "@typescript-eslint/explicit-member-accessibility": [
           1,
           {

--- a/src/three.test.ts
+++ b/src/three.test.ts
@@ -50,23 +50,6 @@ test("instantiates with defaults", () => {
   expect(overlay["overlay"].onDraw).toBeDefined();
 });
 
-test("instantiates with minimal THREE", () => {
-  const overlay = new ThreeJSOverlayView();
-
-  expect(overlay["overlay"]).toBeDefined();
-  expect(overlay["camera"]).toBeInstanceOf(THREE.PerspectiveCamera);
-
-  expect(overlay.scene).toBeInstanceOf(THREE.Scene);
-  expect(overlay.scene.rotation.x).toEqual(Math.PI / 2);
-
-  // required hooks must be defined
-  expect(overlay["overlay"].onAdd).toBeDefined();
-  expect(overlay["overlay"].onRemove).toBeDefined();
-  expect(overlay["overlay"].onContextLost).toBeDefined();
-  expect(overlay["overlay"].onContextRestored).toBeDefined();
-  expect(overlay["overlay"].onDraw).toBeDefined();
-});
-
 test("instantiates with map and calls setMap", () => {
   const map = new Map(
     document.createElement("div"),

--- a/src/three.ts
+++ b/src/three.ts
@@ -35,6 +35,8 @@ export interface ThreeJSOverlayViewOptions {
   scene?: Scene;
 }
 
+/* eslint-disable @typescript-eslint/no-empty-function */
+
 /**
  * Add a [three.js](https://threejs.org) scene as a [Google Maps WebGLOverlayView](http://goo.gle/WebGLOverlayView-ref).
  *
@@ -81,6 +83,7 @@ export class ThreeJSOverlayView implements google.maps.WebGLOverlayView {
     this.overlay.onRemove = this.onRemove.bind(this);
     this.overlay.onContextLost = this.onContextLost.bind(this);
     this.overlay.onContextRestored = this.onContextRestored.bind(this);
+    this.overlay.onStateUpdate = this.onStateUpdate.bind(this);
     this.overlay.onDraw = this.onDraw.bind(this);
 
     this.camera = new PerspectiveCamera();
@@ -89,71 +92,75 @@ export class ThreeJSOverlayView implements google.maps.WebGLOverlayView {
       this.setMap(map);
     }
   }
-  onStateUpdate(options: google.maps.WebGLStateOptions): void {
-    this.overlay.onStateUpdate(options);
-  }
 
-  requestStateUpdate(): void {
+  /**
+   * Override this method to handle any GL state updates outside the
+   * render animation frame.
+   * @param options
+   */
+  public onStateUpdate(options: google.maps.WebGLStateOptions): void {}
+
+  /**
+   * Override this method to fetch or create intermediate data structures
+   * before the overlay is drawn that don’t require immediate access to the
+   * WebGL rendering context.
+   */
+  public onAdd(): void {}
+
+  /**
+   * This method is called when the overlay is removed from the map with
+   * `overlay.setMap(null)`, and is where you can remove all intermediate
+   * objects created in onAdd.
+   */
+  public onRemove(): void {}
+
+  /**
+   * Triggers the map to update GL state.
+   */
+  public requestStateUpdate(): void {
     this.overlay.requestStateUpdate();
   }
 
-  onAdd(): void {}
-
-  onRemove(): void {}
-
-  getMap(): google.maps.Map {
-    return this.overlay.getMap();
-  }
-
-  requestRedraw(): void {
+  /**
+   * Triggers the map to redraw a frame.
+   */
+  public requestRedraw(): void {
     this.overlay.requestRedraw();
   }
 
-  setMap(map: google.maps.Map): void {
+  /**
+   * Returns the map the overlay is added to.
+   */
+  public getMap(): google.maps.Map {
+    return this.overlay.getMap();
+  }
+
+  /**
+   * Adds the overlay to the map.
+   * @param map The map to access the div, model and view state.
+   */
+  public setMap(map: google.maps.Map): void {
     this.overlay.setMap(map);
   }
 
-  addListener(
+  /**
+   * Adds the given listener function to the given event name. Returns an
+   * identifier for this listener that can be used with
+   * <code>google.maps.event.removeListener</code>.
+   */
+  public addListener(
     eventName: string,
-    handler: Function
+    handler: (...args: unknown[]) => void
   ): google.maps.MapsEventListener {
     return this.overlay.addListener(eventName, handler);
   }
 
-  bindTo(
-    key: string,
-    target: google.maps.MVCObject,
-    targetKey?: string,
-    noNotify?: boolean
-  ): void {
-    this.overlay.bindTo(key, target, targetKey, noNotify);
-  }
-
-  get(key: string) {
-    return this.overlay.get(key);
-  }
-
-  notify(key: string): void {
-    this.overlay.notify(key);
-  }
-
-  set(key: string, value: any): void {
-    this.overlay.set(key, value);
-  }
-
-  setValues(values?: object): void {
-    this.overlay.setValues(values);
-  }
-
-  unbind(key: string): void {
-    this.overlay.unbind(key);
-  }
-
-  unbindAll(): void {
-    this.overlay.unbindAll();
-  }
-
-  onContextRestored({ gl }: google.maps.WebGLStateOptions) {
+  /**
+   * This method is called once the rendering context is available. Use it to
+   * initialize or bind any WebGL state such as shaders or buffer objects.
+   * @param options that allow developers to restore the GL context.
+   */
+  public onContextRestored({ gl }: google.maps.WebGLStateOptions) {
     this.renderer = new WebGLRenderer({
       canvas: gl.canvas,
       context: gl,
@@ -172,7 +179,12 @@ export class ThreeJSOverlayView implements google.maps.WebGLOverlayView {
     this.renderer.setViewport(0, 0, width, height);
   }
 
-  onContextLost() {
+  /**
+   * This method is called when the rendering context is lost for any reason,
+   * and is where you should clean up any pre-existing GL state, since it is
+   * no longer needed.
+   */
+  public onContextLost() {
     if (!this.renderer) {
       return;
     }
@@ -181,7 +193,14 @@ export class ThreeJSOverlayView implements google.maps.WebGLOverlayView {
     this.renderer = null;
   }
 
-  onDraw({ gl, transformer }: google.maps.WebGLDrawOptions): void {
+  /**
+   * Implement this method to draw WebGL content directly on the map. Note
+   * that if the overlay needs a new frame drawn then call {@link
+   * ThreeJSOverlayView.requestRedraw}.
+   * @param options that allow developers to render content to an associated
+   *     Google basemap.
+   */
+  public onDraw({ gl, transformer }: google.maps.WebGLDrawOptions): void {
     this.camera.projectionMatrix.fromArray(
       transformer.fromLatLngAltitude(this.anchor, this.rotation, this.scale)
     );
@@ -193,5 +212,64 @@ export class ThreeJSOverlayView implements google.maps.WebGLOverlayView {
 
     // reset state using renderer.resetState() and not renderer.state.reset()
     this.renderer.resetState();
+  }
+
+  // MVCObject interface forwarded to the overlay
+
+  /**
+   * Binds a View to a Model.
+   */
+  public bindTo(
+    key: string,
+    target: google.maps.MVCObject,
+    targetKey?: string,
+    noNotify?: boolean
+  ): void {
+    this.overlay.bindTo(key, target, targetKey, noNotify);
+  }
+
+  /**
+   * Gets a value.
+   */
+  public get(key: string) {
+    return this.overlay.get(key);
+  }
+
+  /**
+   * Notify all observers of a change on this property. This notifies both
+   * objects that are bound to the object&#39;s property as well as the object
+   * that it is bound to.
+   */
+  public notify(key: string): void {
+    this.overlay.notify(key);
+  }
+
+  /**
+   * Sets a value.
+   */
+  public set(key: string, value: unknown): void {
+    this.overlay.set(key, value);
+  }
+
+  /**
+   * Sets a collection of key-value pairs.
+   */
+  public setValues(values?: object): void {
+    this.overlay.setValues(values);
+  }
+
+  /**
+   * Removes a binding. Unbinding will set the unbound property to the current
+   * value. The object will not be notified, as the value has not changed.
+   */
+  public unbind(key: string): void {
+    this.overlay.unbind(key);
+  }
+
+  /**
+   * Removes all bindings.
+   */
+  public unbindAll(): void {
+    this.overlay.unbindAll();
   }
 }

--- a/src/three.ts
+++ b/src/three.ts
@@ -94,18 +94,24 @@ export class ThreeJSOverlayView implements google.maps.WebGLOverlayView {
   }
 
   /**
-   * Override this method to handle any GL state updates outside the
+   * Overwrite this method to handle any GL state updates outside the
    * render animation frame.
    * @param options
    */
   public onStateUpdate(options: google.maps.WebGLStateOptions): void {}
 
   /**
-   * Override this method to fetch or create intermediate data structures
+   * Overwrite this method to fetch or create intermediate data structures
    * before the overlay is drawn that don’t require immediate access to the
    * WebGL rendering context.
    */
   public onAdd(): void {}
+
+  /**
+   * Overwrite this method to update your scene just before a new frame is
+   * drawn.
+   */
+  public onBeforeDraw(): void {}
 
   /**
    * This method is called when the overlay is removed from the map with
@@ -207,11 +213,12 @@ export class ThreeJSOverlayView implements google.maps.WebGLOverlayView {
 
     gl.disable(gl.SCISSOR_TEST);
 
-    this.requestRedraw();
+    this.onBeforeDraw();
     this.renderer.render(this.scene, this.camera);
-
     // reset state using renderer.resetState() and not renderer.state.reset()
     this.renderer.resetState();
+
+    this.requestRedraw();
   }
 
   // MVCObject interface forwarded to the overlay


### PR DESCRIPTION
This introduces a new callback `onBeforeDraw` that can be overwritten by users to implement updates of their scene before a map-frame is rendered.