### PR TITLE
fix: outputEncoding is deprecated in three >= 0.152

### DIFF
--- a/src/three.ts
+++ b/src/three.ts
@@ -28,7 +28,7 @@ import {
   Raycaster,
   RaycasterParameters,
   Scene,
-  sRGBEncoding,
+  SRGBColorSpace,
   Vector2,
   Vector3,
   WebGLRenderer,
@@ -392,7 +392,7 @@ export class ThreeJSOverlayView implements google.maps.WebGLOverlayView {
 
     // LinearEncoding is default for historical reasons
     // https://discourse.threejs.org/t/linearencoding-vs-srgbencoding/23243
-    this.renderer.outputEncoding = sRGBEncoding;
+    this.renderer.outputColorSpace = SRGBColorSpace;
 
     const { width, height } = gl.canvas;
     this.renderer.setViewport(0, 0, width, height);

--- a/src/three.ts
+++ b/src/three.ts
@@ -27,8 +27,9 @@ import {
   Quaternion,
   Raycaster,
   RaycasterParameters,
+  REVISION,
   Scene,
-  SRGBColorSpace,
+  sRGBEncoding,
   Vector2,
   Vector3,
   WebGLRenderer,
@@ -390,9 +391,9 @@ export class ThreeJSOverlayView implements google.maps.WebGLOverlayView {
     this.renderer.shadowMap.enabled = true;
     this.renderer.shadowMap.type = PCFSoftShadowMap;
 
-    // LinearEncoding is default for historical reasons
-    // https://discourse.threejs.org/t/linearencoding-vs-srgbencoding/23243
-    this.renderer.outputColorSpace = SRGBColorSpace;
+    // Since r152, default outputColorSpace is SRGB
+    // Deprecated outputEncoding kept for backwards compatibility
+    if (Number(REVISION) < 152) this.renderer.outputEncoding = sRGBEncoding;
 
     const { width, height } = gl.canvas;
     this.renderer.setViewport(0, 0, width, height);


### PR DESCRIPTION
Simple import/name change

Fixes #742
