### PR TITLE
fix: stop importing sRGBEncoding constant

### DIFF
--- a/src/three.ts
+++ b/src/three.ts
@@ -29,7 +29,6 @@ import {
   RaycasterParameters,
   REVISION,
   Scene,
-  sRGBEncoding,
   Vector2,
   Vector3,
   WebGLRenderer,
@@ -37,6 +36,11 @@ import {
 import { latLngToVector3Relative, toLatLngAltitudeLiteral } from "./util";
 
 import type { LatLngTypes } from "./util";
+
+// Since r162, the sRGBEncoding constant is no longer exported from three.
+// The value is kept here to keep compatibility with older three.js versions.
+// This will be removed with the next major release.
+const sRGBEncoding = 3001;
 
 const DEFAULT_UP = new Vector3(0, 0, 1);
 

--- a/src/three.ts
+++ b/src/three.ts
@@ -398,7 +398,10 @@ export class ThreeJSOverlayView implements google.maps.WebGLOverlayView {
 
     // Since r152, default outputColorSpace is SRGB
     // Deprecated outputEncoding kept for backwards compatibility
-    if (Number(REVISION) < 152) this.renderer.outputEncoding = sRGBEncoding;
+    if (Number(REVISION) < 152) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (this.renderer as any).outputEncoding = sRGBEncoding;
+    }
 
     const { width, height } = gl.canvas;
     this.renderer.setViewport(0, 0, width, height);


### PR DESCRIPTION
Since r162, three.js no longer exports the formerly deprecated sRGBEncoding constant. This replaces the import with the literal value to keep compatibility with older three.js versions until we release a new major version.

fixes #1036