### PR TITLE
fix(tests): add explicit typing for raycaster-params in test

### DIFF
--- a/src/__tests__/three.test.ts
+++ b/src/__tests__/three.test.ts
@@ -36,6 +36,7 @@ import {
   Mesh,
   Object3D,
   PerspectiveCamera,
+  RaycasterParameters,
   Scene,
   Vector2,
   Vector3,
@@ -427,8 +428,9 @@ describe("raycast()", () => {
   test("sets and restores raycaster parameters", () => {
     const raycaster = overlay["raycaster"];
 
-    const origParams = {};
-    const customParams = {};
+    const origParams = {} as unknown as RaycasterParameters;
+    const customParams = {} as unknown as RaycasterParameters;
+
     let currParams = origParams;
     let intersectParams = null;
 


### PR DESCRIPTION
Newer versions of `@types/three` contain stricter types for `RaycasterParameters`, causing the tests to fail. This adds explicit typecasts to our tests to make the errors go away.

This will unblock the failed tests in #1018.